### PR TITLE
Use JSON to represent repo references

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,15 @@
 name: 'Backlog Notifier'
 description: 'Automatically comments on tickets connected to your PRs, with the release version, when they get released.'
 inputs:
-  reference-repo-prefixes:
-    description: 'Prefixes for issue numbers of reference repos. You can specify multiple comma-separated ones. The should be single words like BACKLOG or BUGLOG which could identify repos for backlog and bug tickets respectively. A complete identifier, as the action searches it in the PR description, should consist of this prefix and the issue number separated by a dash, e.g. `BACKLOG-539`.'
+  repo-references:
+    description: 'Unique, human readable (1) identifiers and (2) repository names in JSON format. (1) are used as prefixes for issue numbers in PR description bodies. (2) The names of the linked repositories. Both are specified as list of associated arrays. You can specify as many ID/repo combinations as you want. The identifiers should be single words, like BACKLOG or BUGLOG which e.g. could identify repos for backlog and bug tickets. The ID, as the action searches it in the PR description, should be the prefix of the issue number. Prefix and the issue number must be separated by a dash, e.g. `BACKLOG-539`.'
     required: true
-    default: 'BACKLOG'
-  reference-repo-names:
-    description: 'Repository names that contain tickets to notify. This list must have the same number of elements as the repository prefixes list. Specify one repository name for each prefix. The repository must be located under the same GitHub account as the repository you use this action on.'
-    required: true
-    default: 'backlog'
+    default: |
+      {
+        "data": [
+          {"repo_id": "BACKLOG", "repo_name": "backlog"}
+        ]
+      }
   message:
     description: 'The message that is posted in the backlog ticket. Use `#` as placeholder for the version number.'
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -10357,23 +10357,22 @@ async function run() {
     const owner = `${payload.repository.owner.login}`;
     const repo = `${payload.repository.name}`;
 
-    const referenceRepoNames = Array.from(new Set(core.getInput('reference-repo-names').split(',').map(string => string.trim())))
-    const referenceRepoPrefixes = Array.from(new Set(core.getInput('reference-repo-prefixes').split(',').map(string => string.trim())))
+    // Parse JSON inputs and trim string values
+
+    const repoReferences = JSON.parse(core.getInput('repo-references'), (key, value) => {
+        return typeof value === "string" ? value.trim() : value;
+    })
+
     const message = core.getInput('message').replace('#', `[${tag}](${tagUrl})`);
     const changelogPath = core.getInput('changelog-path');
 
     console.log(`🟢 tag: ${tag}`);
     console.log(`🟢 tagUrl: ${tagUrl}`);
     console.log(`🟢 owner: ${owner}`);
-    console.log(`🟢 referenceRepoNames: ${referenceRepoNames} (${referenceRepoNames.length})`);
-    console.log(`🟢 referenceRepoPrefixes: ${referenceRepoPrefixes} (${referenceRepoPrefixes.length})`);
+    console.log(`🟢 Repo References: ${JSON.stringify(repoReferences.data, null, '\t')}`);
     console.log(`🟢 changelogPath: ${changelogPath}`);
     console.log(`🟢 message: ${message}`);
-    console.log(`🟢 The event payload: ${JSON.stringify(payload, null, '\t')})`);
-
-
-    if (referenceRepoNames.length != referenceRepoPrefixes.length)
-      throw Error('🔴 Different count in arrays "reference-repo-names" and "reference-repo-prefixes" Please specify same length. Repo names and repo prefixed must match.');
+    console.log(`🟢 The event payload: ${JSON.stringify(payload, null, '\t')}`);
 
     if (!`${payload.ref}`.startsWith('refs/tags/'))
       throw Error('🔴 The trigger for this action was not a tag reference!');
@@ -10408,14 +10407,15 @@ async function run() {
     for (const id of uniqueIssueIds) {
       const issueData = await getIssue(owner, repo, id, octokit)
 
-      for (const [i, prefix] of referenceRepoPrefixes.entries()) {
-        const repoName = referenceRepoNames[i]
+      for (const reference of repoReferences.data) {
+        let repoID = reference.repo_id
+        let repoName = reference.repo_name
 
-        let expression = new RegExp(`${prefix}-[0-9]+`, 'g')
+        let expression = new RegExp(`${repoID}-[0-9]+`, 'g')
         let matches = issueData.body.match(expression)
 
         if (matches == null) {
-          console.log(`🟡 No issue references found for "${prefix}" on PR "${issueData.html_url}". Please specify them using the pattern "${prefix}-<number>"`)
+          console.log(`🟡 No issue references found for "${repoID}" on PR "${issueData.html_url}". Please specify them using the pattern "${repoID}-<number>"`)
           continue
         }
 


### PR DESCRIPTION
# Changes

Since Github Actions [do not support associative array for the inputs](https://stackoverflow.com/a/75420778/971329) we switched to represent this using JSON. This is just a simple string which can be parsed and validated in the action.

The advantage of this approach is that repo names and references are tightly coupled and don't fly around in separate lists. The structure is also extensible in future if we need another parameter, e.g. repo owner to reference issues from different github users/organizations.

> [!NOTE]  
> This resolves the issue below, but in a different way. 

# Issues

Resolve #23